### PR TITLE
bug 194025: Date formatting changes

### DIFF
--- a/CheckYourEligibility-Admin/Controllers/ApplicationController.cs
+++ b/CheckYourEligibility-Admin/Controllers/ApplicationController.cs
@@ -387,9 +387,9 @@ namespace CheckYourEligibility_FrontEnd.Controllers
                 Reference = x.Reference,
                 Parent = $"{x.ParentFirstName} {x.ParentLastName}",
                 Child = $"{x.ChildFirstName} {x.ChildLastName}",
-                ChildDOB = Convert.ToDateTime(x.ChildDateOfBirth).ToString("dd MMM yyyy"),
+                ChildDOB = Convert.ToDateTime(x.ChildDateOfBirth).ToString("d MMM yyyy"),
                 Status = x.Status.GetFsmStatusDescription(),
-                SubmisionDate = x.Created.ToString("dd MMM yyyy")
+                SubmisionDate = x.Created.ToString("d MMM yyyy")
 
             }));
             var memoryStream = new MemoryStream(result);
@@ -542,8 +542,8 @@ namespace CheckYourEligibility_FrontEnd.Controllers
                 ChildName = $"{response.Data.ChildFirstName} {response.Data.ChildLastName}",
                 School = response.Data.Establishment.Name,
             };
-            viewData.ParentDob = DateTime.ParseExact(response.Data.ParentDateOfBirth, "yyyy-MM-dd", CultureInfo.InvariantCulture).ToString("dd MMMM yyyy");
-            viewData.ChildDob = DateTime.ParseExact(response.Data.ChildDateOfBirth, "yyyy-MM-dd", CultureInfo.InvariantCulture).ToString("dd MMMM yyyy");
+            viewData.ParentDob = DateTime.ParseExact(response.Data.ParentDateOfBirth, "yyyy-MM-dd", CultureInfo.InvariantCulture).ToString("d MMMM yyyy");
+            viewData.ChildDob = DateTime.ParseExact(response.Data.ChildDateOfBirth, "yyyy-MM-dd", CultureInfo.InvariantCulture).ToString("d MMMM yyyy");
 
             return viewData;
         }

--- a/CheckYourEligibility-Admin/Views/Application/AppealsApplications.cshtml
+++ b/CheckYourEligibility-Admin/Views/Application/AppealsApplications.cshtml
@@ -57,8 +57,12 @@
                 </thead>
                 @Html.EditorFor(model => model.People)
             </table>
-
         }
+        else
+        {
+            <p>No results found.</p>
+        }
+
         @{
             var paginationModel = new PaginationPartialViewModel
             {
@@ -70,11 +74,6 @@
             };
 
             @Html.Partial("PaginationPartial", paginationModel)
-        }
-        }
-        else
-        {
-        <p>No results found.</p>
         }
     </div>
 </div>

--- a/CheckYourEligibility-Admin/Views/Application/EditorTemplates/SelectPersonEditorViewModel.cshtml
+++ b/CheckYourEligibility-Admin/Views/Application/EditorTemplates/SelectPersonEditorViewModel.cshtml
@@ -43,11 +43,11 @@
     <td class="govuk-table__cell">@(@Model.Person.ChildFirstName + " " + Model.Person.ChildLastName)</td>
     @if (Model.ShowParentDob)
     {
-        <td class="govuk-table__cell">@Convert.ToDateTime(Model.Person.ParentDateOfBirth).ToString("dd MMM yyyy")</td>
+        <td class="govuk-table__cell">@Convert.ToDateTime(Model.Person.ParentDateOfBirth).ToString("d MMM yyyy")</td>
     }
     else
     {
-        <td class="govuk-table__cell">@Convert.ToDateTime(Model.Person.ChildDateOfBirth).ToString("dd MMM yyyy")</td>
+        <td class="govuk-table__cell">@Convert.ToDateTime(Model.Person.ChildDateOfBirth).ToString("d MMM yyyy")</td>
     }
     @if(Model.ShowSchool)
     {
@@ -61,7 +61,7 @@
         </strong>
     </td>
     }
-    <td class="govuk-table__cell">@Model.Person.Created.ToString("dd MMM yyyy")</td>
+    <td class="govuk-table__cell">@Model.Person.Created.ToString("d MMM yyyy")</td>
   
    
 </tr>

--- a/CheckYourEligibility-Admin/Views/Application/PendingApplications.cshtml
+++ b/CheckYourEligibility-Admin/Views/Application/PendingApplications.cshtml
@@ -67,10 +67,10 @@
                         <td></td>
                         <td class="govuk-table__cell">@Html.ActionLink(person.Person.Reference, person.DetailView, "application", new { id = person.Person.Id }, new { @class = "govuk-link" })</td>
                         <td class="govuk-table__cell">@(@person.Person.ParentFirstName + " " + @person.Person.ParentLastName)</td>
-                        <td class="govuk-table__cell">@Convert.ToDateTime(person.Person.ParentDateOfBirth).ToString("dd MMM yyyy")</td>
+                        <td class="govuk-table__cell">@Convert.ToDateTime(person.Person.ParentDateOfBirth).ToString("d MMM yyyy")</td>
                         <td class="govuk-table__cell">@(@person.Person.ChildFirstName + " " + person.Person.ChildLastName)</td>
                         <td class="govuk-table__cell">@(@person.Person.Establishment.Name)</td>
-                        <td class="govuk-table__cell">@person.Person.Created.ToString("dd MMM yyyy")</td>
+                        <td class="govuk-table__cell">@person.Person.Created.ToString("d MMM yyyy")</td>
                     </tr>
                 }
             </tbody>

--- a/CheckYourEligibility-Admin/Views/Application/SearchResults.cshtml
+++ b/CheckYourEligibility-Admin/Views/Application/SearchResults.cshtml
@@ -1,5 +1,6 @@
 ﻿@using CheckYourEligibility_FrontEnd.ViewModels
-@model PeopleSelectionViewModel;
+@using System.Collections.Generic;
+@model PeopleSelectionViewModel
 
 @{
     ViewData["Title"] = "Search results (" + @ViewBag.TotalRecords + ")";
@@ -8,8 +9,10 @@
     int currentPage = ViewBag.CurrentPage ?? 1;
     int totalRecords = ViewBag.TotalRecords;
     int totalPages = (int)Math.Ceiling((double)totalRecords / recordsPerPage);
+}
 
-    Dictionary<string, string> statusColor = new Dictionary<string, string>
+@{
+    var statusColor = new Dictionary<string, string>()
     {
         {"Entitled", "govuk-tag--green"},
         {"EvidenceNeeded", "govuk-tag--light-blue"},
@@ -19,7 +22,7 @@
         {"ReviewedNotEntitled", "govuk--tag-red"}
     };
 
-    Dictionary<string, string> statusName = new Dictionary<string, string>
+    var statusName = new Dictionary<string, string>()
     {
         {"Entitled", "Entitled"},
         {"EvidenceNeeded", "Evidence Needed"},
@@ -28,8 +31,6 @@
         {"ReviewedEntitled", "Reviewed Entitled"},
         {"ReviewedNotEntitled", "Reviewed Not Entitled"}
     };
-
-
 }
 
 @* <a class="govuk-back-link" href="#" onclick="history.back(); return false;">Back</a>*@
@@ -77,8 +78,8 @@
                 <tr>
                     <td class="govuk-table__cell">@Html.ActionLink(person.Person.Reference, person.DetailView, "application", new { id = person.Person.Id }, new { @class = "govuk-link" })</td>
                     <td class="govuk-table__cell">@(@person.Person.ChildFirstName + " " + @person.Person.ChildLastName)</td>
-                    <td class="govuk-table__cell">@Convert.ToDateTime(person.Person.ChildDateOfBirth).ToString("dd MMM yyyy")</td>
-                    <td class="govuk-table__cell">@(Convert.ToDateTime(@person.Person.Created).ToString("dd MMM yyyy"))</td>
+                    <td class="govuk-table__cell">@Convert.ToDateTime(person.Person.ChildDateOfBirth).ToString("d MMM yyyy")</td>
+                    <td class="govuk-table__cell">@(Convert.ToDateTime(@person.Person.Created).ToString("d MMM yyyy"))</td>
                     <td class="govuk-table__cell">
                         <strong class="govuk-tag @statusColor[person.Person.Status]">
                             @statusName[person.Person.Status]

--- a/CheckYourEligibility-Admin/Views/Check/Check_Answers.cshtml
+++ b/CheckYourEligibility-Admin/Views/Check/Check_Answers.cshtml
@@ -38,7 +38,7 @@
                             Date of birth
                         </dt>
                         <dd class="govuk-summary-list__value">
-                            @Model.ParentDateOfBirth
+                            @DateTime.Parse(@Model.ParentDateOfBirth).ToString("d MMMM yyyy");
                         </dd>
                     </div>
 
@@ -82,7 +82,7 @@
         @for (var i = 0; i < Model.Children.ChildList.Count; i++)
         {
             var child = Model.Children.ChildList[i];
-            string formattedChildDob = $"{child.Day.PadLeft(2, '0')}/{child.Month.PadLeft(2, '0')}/{child.Year}";
+            string formattedChildDob = DateTime.Parse($"{child.Day}/{child.Month}/{child.Year}").ToString("d MMMM yyyy");
             <div class="govuk-summary-card">
                 <div class="govuk-summary-card__title-wrapper">
                     <h2 class="govuk-summary-card__title">

--- a/tests/cypress/e2e/Admin/AdminFullE2EJourney.spec.ts
+++ b/tests/cypress/e2e/Admin/AdminFullE2EJourney.spec.ts
@@ -118,7 +118,7 @@ describe('Full journey of creating an application through school portal through 
         cy.get('h1').should('include.text', 'Check your answers before submitting');
 
         cy.CheckValuesInSummaryCard('Parent or guardian details', 'Name', `${parentFirstName} ${parentLastName}`);
-        cy.CheckValuesInSummaryCard('Parent or guardian details', 'Date of birth', '1 Jan 1990');
+        cy.CheckValuesInSummaryCard('Parent or guardian details', 'Date of birth', '1 January 1990');
         cy.CheckValuesInSummaryCard('Parent or guardian details', 'National Insurance number', "NN123456C");
         cy.CheckValuesInSummaryCard('Parent or guardian details', 'Email address', parentEmailAddress);
         cy.CheckValuesInSummaryCard('Child 1 details', "Name", childFirstName + " " + childLastName);

--- a/tests/cypress/e2e/Admin/AdminFullE2EJourney.spec.ts
+++ b/tests/cypress/e2e/Admin/AdminFullE2EJourney.spec.ts
@@ -45,7 +45,7 @@ describe('Full journey of creating an application through school portal through 
         cy.get('h1').should('include.text', 'Check your answers before submitting');
 
         cy.CheckValuesInSummaryCard('Parent or guardian details', 'Name', `${parentFirstName} ${parentLastName}`);
-        cy.CheckValuesInSummaryCard('Parent or guardian details', 'Date of birth', '1990-01-01');
+        cy.CheckValuesInSummaryCard('Parent or guardian details', 'Date of birth', '1 January 1990');
         cy.CheckValuesInSummaryCard('Parent or guardian details', 'National Insurance number', NIN);
         cy.CheckValuesInSummaryCard('Parent or guardian details', 'Email address', parentEmailAddress);
         cy.CheckValuesInSummaryCard('Child 1 details', "Name", childFirstName + " " + childLastName);
@@ -118,7 +118,7 @@ describe('Full journey of creating an application through school portal through 
         cy.get('h1').should('include.text', 'Check your answers before submitting');
 
         cy.CheckValuesInSummaryCard('Parent or guardian details', 'Name', `${parentFirstName} ${parentLastName}`);
-        cy.CheckValuesInSummaryCard('Parent or guardian details', 'Date of birth', '1990-01-01');
+        cy.CheckValuesInSummaryCard('Parent or guardian details', 'Date of birth', '1 Jan 1990');
         cy.CheckValuesInSummaryCard('Parent or guardian details', 'National Insurance number', "NN123456C");
         cy.CheckValuesInSummaryCard('Parent or guardian details', 'Email address', parentEmailAddress);
         cy.CheckValuesInSummaryCard('Child 1 details', "Name", childFirstName + " " + childLastName);

--- a/tests/cypress/e2e/Admin/AdminSearchApplication.spec.ts
+++ b/tests/cypress/e2e/Admin/AdminSearchApplication.spec.ts
@@ -52,7 +52,7 @@ describe('Admin journey search for application', () => {
         cy.get('h1').should('include.text', 'Check your answers before submitting');
 
         cy.CheckValuesInSummaryCard('Parent or guardian details', 'Name', `${parentFirstName} ${parentLastName}`);
-        cy.CheckValuesInSummaryCard('Parent or guardian details', 'Date of birth', '1990-01-01');
+        cy.CheckValuesInSummaryCard('Parent or guardian details', 'Date of birth', '1 January 1990');
         cy.CheckValuesInSummaryCard('Parent or guardian details', 'National Insurance number', NIN);
         cy.CheckValuesInSummaryCard('Parent or guardian details', 'Email address', parentEmailAddress);
         cy.CheckValuesInSummaryCard('Child 1 details', "Name", childFirstName + " " + childLastName);
@@ -164,7 +164,7 @@ describe('Admin journey search for application', () => {
             .eq(0)
             .find('td')
             .eq(2)
-            .should('contain.text', '01 Jan 2007');
+            .should('contain.text', '1 Jan 2007');
     });
 
     //    it('Will allow School users to search for an application with a selected Parent of Guardian DOB', () => {


### PR DESCRIPTION
Bug item: 194025 

Updated the format for dates displayed across the portal.

- All day parts, that are single digit numbers, will be displayed without a leading 0 (7 not 07).
- Where the date is part of a table use short month format (Feb, Jun, Oct).
- Where the date is NOT part of a table use long month format (February, June, October).

Had to make changes to `searchResults.cshtml`, it seems that the latest version of main (at least at the time of starting & completing this bug) had an error caused by the C# syntax at the top of the view page - my edits only aim to remove these errors 